### PR TITLE
#163031549 Build the fetch all upcoming meetups api endpoint

### DIFF
--- a/app/api/v1/models/meetup_record_models.py
+++ b/app/api/v1/models/meetup_record_models.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-
+from uuid import uuid4
 
 class MeetupRecord:
     """ Creates the meetup record model """
@@ -16,12 +16,13 @@ class MeetupRecord:
         self.tags = tags
 
         new_meetup = {
-            "meetupId": meetupId,
-            "createdOn": createdOn,
-            "location": location,
-            "images": images,
-            "happeningOn": happeningOn,
-            "Tags": tags
-
-        }
+        "status": 201,
+        "data": [{
+            "id": uuid4().int,
+            "topic": "The topic",
+            "location": "The venue",
+            "happeningOn": "The meetup date.",
+            "tags": ["tag1", "tag2", "tag3"]
+        }]
+    }
         self.all_meetup_records.append(new_meetup)

--- a/app/api/v1/views/meetup_record_views.py
+++ b/app/api/v1/views/meetup_record_views.py
@@ -28,3 +28,7 @@ def post_question():
             "tags": ["tag1", "tag2", "tag3"]
         }]
     }), 201
+
+@v1_meetup_blueprint.route('/meetups/upcoming', methods=['GET'])
+def get_all_meetups():
+    return jsonify(meetup.all_meetup_records)

--- a/app/tests/v1/test_meetup_records.py
+++ b/app/tests/v1/test_meetup_records.py
@@ -29,6 +29,12 @@ class TestQuestionModels(unittest.TestCase):
         self.assertIn("The meetup date.", str(self.meetup))
         self.assertIn("images", str(self.meetup))
 
+    def test_api_can_fetch_all_meetup_records(self):
+        res = self.client.post('/api/v1/meetups', data=json.dumps(self.meetup), content_type='application/json')
+        self.assertEqual(res.status_code, 201)
+        res = self.client.get('/api/v1/meetups/upcoming', content_type='application/json')
+        self.assertEqual(res.status_code, 200)
+        self.assertIn("The meetup date.", str(self.meetup))
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
#### What does this PR do?
This pull request creates the fetch all meetup records API endpoint.
#### Description of task to be completed
* Create a failing test to test that the API fails with an assertion error before writing the functionality code.
* Build out  the `api/v1 /meetups/upcoming` API endpoint to fetch all meetups
* Run your test again to ensure it passes
#### How should this be manually tested?
1. `git clone` this repo. and cd into it.
>`https://github.com/SolomonMacharia/Questioner.git`
2. Create a virtual environment.
>`python3 -m venv env`
3. Activate the virtual environment.
>`source env/bin/activate`
4. Install the requirements.
>`pip install -r requirements.txt`
5. Run the command `pytest` in your terminal to run the test
6. Run the application.
>`flask run`
7. Using postman, test the **GET** `api/v1/meetups/upcoming` endpoint.
#### What are the relevant pivotal tracker stories?
https://www.pivotaltracker.com/story/show/163031549
#163031549
#### Screenshots
![screenshot from 2019-01-09 04-17-48](https://user-images.githubusercontent.com/41987551/50870927-139f3300-13cb-11e9-98ce-583d064c1d2d.png)
![screenshot from 2019-01-09 04-34-47](https://user-images.githubusercontent.com/41987551/50870961-2b76b700-13cb-11e9-9f20-cc769569165e.png)
![screenshot from 2019-01-09 01-51-29](https://user-images.githubusercontent.com/41987551/50871073-88726d00-13cb-11e9-8892-eb291efe597d.png)

