### PR TITLE
#163031251 Build an API endpoint to fetch a single meetup

### DIFF
--- a/app/api/v1/models/meetup_record_models.py
+++ b/app/api/v1/models/meetup_record_models.py
@@ -1,3 +1,4 @@
+from flask import jsonify, abort
 from datetime import datetime
 from uuid import uuid4
 
@@ -26,3 +27,10 @@ class MeetupRecord:
         }]
     }
         self.all_meetup_records.append(new_meetup)
+
+    def fetch_single_meetup(self, meetupId):
+        """ Fetches a single meetup based on the meetupId"""
+        for meetup in self.all_meetup_records:
+            if meetupId == int(meetupId):
+                return meetup
+        return abort(404, "Error: Meetup {} does'nt exist.".format(meetupId))

--- a/app/api/v1/views/meetup_record_views.py
+++ b/app/api/v1/views/meetup_record_views.py
@@ -32,3 +32,8 @@ def post_question():
 @v1_meetup_blueprint.route('/meetups/upcoming', methods=['GET'])
 def get_all_meetups():
     return jsonify(meetup.all_meetup_records)
+
+@v1_meetup_blueprint.route('/meetups/upcoming/<int:meetupId>', methods=['GET'])
+def get_single_meetup(meetupId):
+    singleMeetup = meetup.fetch_single_meetup(meetupId)
+    return jsonify(singleMeetup)

--- a/app/tests/v1/test_meetup_records.py
+++ b/app/tests/v1/test_meetup_records.py
@@ -36,5 +36,10 @@ class TestQuestionModels(unittest.TestCase):
         self.assertEqual(res.status_code, 200)
         self.assertIn("The meetup date.", str(self.meetup))
 
+    def test_api_can_fetch_single_meetup_record(self):
+        res = self.client.post('/api/v1/meetups', data=json.dumps(self.meetup), content_type='application/json')
+        self.assertEqual(res.status_code, 201)
+        res = self.client.get('/api/v1/meetups/upcoming/1', content_type='application/json')
+        self.assertEqual(res.status_code, 200)
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
#### What does this PR do?
This pull request creates a fetch one record endpoint that fetches a specific meetup based on the Id.
#### Description of task to be completed
* Create a failing test to test that the API fails with an assertion error before writing the functionality.
* Build out  the `api/v1 /questions` API endpoint to fetch a meetup
* Make the failing test pass
#### How should this be manually tested?
1. `git clone` this repo. and cd into it.
>`https://github.com/SolomonMacharia/Questioner.git`
2. Create a virtual environment.
>`python3 -m venv env`
3. Activate the virtual environment.
>`source env/bin/activate`
4. Install the requirements.
>`pip install -r requirements.txt`
5. Run the command `pytest` in your terminal to run the test
6. Run the application.
>`flask run`
7. Using postman, test the **GET** `api/v1/meetups/upcoming/<int:meetupId>` endpoint.
#### What are the relevant pivotal tracker stories?
https://www.pivotaltracker.com/story/show/163031251
`#163031251`
#### Screenshots
![screenshot from 2019-01-09 10-45-45](https://user-images.githubusercontent.com/41987551/50884372-c8e9df00-13fb-11e9-914e-d92dfbfafad6.png)
