### PR TITLE
#163106327 Build api endpoint to get one question

### DIFF
--- a/app/api/v1/models/question_record_models.py
+++ b/app/api/v1/models/question_record_models.py
@@ -16,7 +16,7 @@ class QuestionRecord():
         self.body = body
         self.votes = []
         new_question = {
-            "question_id": qstnId,
+            "qstnId": qstnId,
             "createdOn": createdOn,
             "createdBy": createdBy,
             "meetupId": meetupId,

--- a/app/api/v1/views/question_record_views.py
+++ b/app/api/v1/views/question_record_views.py
@@ -31,9 +31,15 @@ def post_question():
             "votes": question.votes
         }]
     }), 201
+
 @v1_questions_blueprint.route('/questions', methods=['GET'])
 def get_all_questions():
     return jsonify({"All_questions": question.all_question_records}), 200
+
+@v1_questions_blueprint.route('/questions/<int:qstnId>', methods=['GET'])
+def get_one_question(qstnId):
+    oneqstn = [qstn for qstn in question.all_question_records if qstn['qstnId'] == qstnId]
+    return jsonify({"question": oneqstn[0]}), 200
 
 @v1_questions_blueprint.route('/questions/<int:qstnId>/upvote', methods=['PATCH'])
 def upvote(qstnId):

--- a/app/tests/v1/test_question_record_views.py
+++ b/app/tests/v1/test_question_record_views.py
@@ -13,7 +13,7 @@ class TestQuestionModels(unittest.TestCase):
         self.app = create_app()
         self.client = self.app.test_client()
         self.question = {
-            "id": "qstnId",
+            "qstnId": "qstnId",
             # "createdOn": datetime.now(),
             "createdBy": "userId",
             "meetupId": "MeetupId",
@@ -33,6 +33,12 @@ class TestQuestionModels(unittest.TestCase):
     def test_api_can_get_all_questions(self):
             res = self.client.get('/api/v1/questions', data=json.dumps(self.question), content_type='application/json')
             self.assertEqual(res.status_code, 200)
+
+    def test_api_can_get_one_question(self):
+        res = self.client.post('/api/v1/questions', data=json.dumps(self.question), content_type='application/json')
+        self.assertEqual(res.status_code, 201)
+        res = self.client.get('/api/v1/questions/1', content_type='application/json')
+        self.assertEqual(res.status_code, 200)
 
     def test_api_can_upvote_a_question(self):
         res = self.client.patch('/api/v1/questions/1/upvote', data=json.dumps(self.question))


### PR DESCRIPTION
#### What does this PR do?
This pull request creates the get one question endpoint.
#### Description of task to be completed
* Create a failing test to test that the API fails with an assertion error before writing the functionality.
* Build out  the `api/v1 /questions/<questionId>` api endpoint to post a question and  make the test pass
#### How should this be manually tested?
1. `git clone` this repo. and cd into it.
>`https://github.com/SolomonMacharia/Questioner.git`
2. Create a virtual environment.
>`python3 -m venv env`
3. Activate the virtual environment.
>`source env/bin/activate`
4. Install the requirements.
>`pip install -r requirements.txt`
5. Run the application.
>`flask run`
6. Using postman, test the **GET** `api/v1/questions/<questionId>` endpoint.
#### What are the relevant pivotal tracker stories?
https://www.pivotaltracker.com/story/show/163106327
#163106327
#### Screenshots
![screenshot from 2019-01-10 04-31-13](https://user-images.githubusercontent.com/41987551/50940972-1ade4380-1494-11e9-8752-5c88dc1c64ad.png)
